### PR TITLE
Minor cleanups

### DIFF
--- a/StartupSession/Dyalog/Array.apln
+++ b/StartupSession/Dyalog/Array.apln
@@ -64,13 +64,13 @@
                   repr←or,(Join ⎕SRC ref),nl,cr
               :Else
                   repr←or nl
-         
+
                   names←##.sysVars/⍨≢⌿ref ref.##∘.⍎##.sysVars
                   names,←ref.⎕NL-⍳9
-         
+
                   :For name :In names
                       code←Join ref.⎕NR name
-         
+
                       :Select ref.⎕NC⊂name
                       :CaseList 3.1 4.1
                           repr,←name,':(∇',code,nl,'∇)'
@@ -89,7 +89,7 @@
                       :EndSelect
                       repr,←nl
                   :EndFor
-         
+
                   repr,←cr
               :EndTrap
           :Else
@@ -133,19 +133,19 @@
               ⍺←⊃⎕RSI
               (Simple∧Scal)⍵:Repr ⍵
               Scal ⍵:ec,⍺ ∇⊃⍵
-         
+
               Self←⊂nl,⍨∇
-         
+
               (Any0<Num∧Table)⍵:Join os,cs,⍨{(+/∨\' '≠⌽⍵)↑¨↓⍵}⎕FMT ⍵
               (Any0<Table>Col1)⍵:Join os,cs,⍨{(+/∨\' '≠⌽⍵)↑¨↓⍵}0 1↓⊃,/' ',¨↑¨↓⍉(∨/'⎕UCS'⍷##.string ⎕R'')_Paren_(⍺∘∇)¨⍵
               HiRank ⍵:Self⍤¯1 _Sub_ os cs⊢⍵
               Nested ⍵:Self¨_Sub_ or cr⊢⍵
-         
+
               Vec1 ⍵:or,(⍺ ∇⊃⍵),di cr
-         
+
               (Basic∨Scal)⍵:Repr ⍵
               ∧/Basic¨⍵:sp Join(6≤≢)_Paren_ Repr¨⍵
-         
+
               Self¨_Sub_ or cr⊢⍵ ⍝ hetero
           }
     :EndNamespace
@@ -153,7 +153,7 @@
           ⍺←⍬
           num←serialise.FirstNum ⍺,0
           caller←serialise.FirstNs ⍺,⊃⎕RSI
-     
+
           Bad←{(caller code)←⍵
               '+'∊⍺:0
               value←¯1 Deserialise caller.{⍺ ⍺⍺ ⍵}code ⍝ deserialise in caller namespace to have proper ⎕FR
@@ -161,7 +161,7 @@
           }
           code←caller serialise.Ser ⍵
           ⍺ Bad caller code:'It would not be possible to deserialise the generated array notation'⎕SIGNAL 16
-     
+
           code Format⍨1∊⍺
       }
 
@@ -169,10 +169,10 @@
           Split←{(+/∨\' '≠⌽⍵)↑¨↓⍵}⎕FMT
                                         ⍝ change "(⋄" to just "("
           'AIX'≢3↑⊃# ⎕WG'APLVersion':¯1↓'''[^'']*''' '\(⋄'⎕R'\0' '('Split ⍺ ∆FMTAPLAN Split ⍵
-     
+
           split←Split ⍵
           ⍺:string'([[(]) ⋄ ' ' ⋄ ([])])' '  +'⎕R'&' '\1' ' ⋄\1' ' '⊢3↓∊' ⋄ '∘,¨split
-     
+
           code←string ⎕R'⋄'⊢⍵                     ⍝ remove quoted text first
           fmt←⎕FMT'\[[^][]+\]' '\([^)(]+\)'⎕R''⍣≡code  ⍝ remove bracket contents
           delta←(+/'(['∊⍨fmt)-(+/fmt∊')]')
@@ -199,30 +199,30 @@
           ⍺←⍬ ⍝ 1=safe exec expr; 0=return expr; ¯1=unsafe exec expr; ¯2=force APL model
           (model beSafe execute)←(¯2∘=,0∘⌈,1⌊|)serialise.FirstNum ⍺,1
           caller←serialise.FirstNs ⍺,⊃⎕RSI
-     
+
           ⍝ Make normalised simple vector:
           w←↓⍣(2=≢⍴⍵)⊢⍵                  ⍝ if mat, make nested
           w←{¯1↓∊⍵,¨⎕UCS 13}⍣(2=|≡w)⊢w   ⍝ if nested, make simple
-     
+
           beSafe>Safe w:⎕SIGNAL⊂('EN' 11)('Message' 'Unsafe array notation')
                                                           ⍝ fall back to APL model on error
           model<execute∧'AIX'≢3↑⊃# ⎕WG'APLVersion':caller ∇{2::⍵ ⍺⍺⍨¯2,⍺ ⋄ ⍺ ∆APLAN,⍵}w
-     
+
           q←''''
           ⎕IO←0
           SEP←'⋄',⎕UCS 10 13
-     
+
           Unquot←{(⍺⍺ ⍵)×~≠\q=⍵}
           SepMask←∊∘SEP Unquot
           ParenLev←+\(×¯3+7|¯3+'([{)]}'∘⍳)Unquot
-     
+
           Paren←1⌽')(',⊢
           Split←{1↓¨⍺⍺⊂Over(1∘,)⍵}
-     
+
           Over←{(⍵⍵ ⍺)⍺⍺(⍵⍵ ⍵)}
           EachIfAny←{0=≢⍵:⍵ ⋄ ⍺ ⍺⍺¨⍵}
           EachNonempty←{⍺ ⍺⍺ EachIfAny Over((×≢¨⍵~¨' ')/⊢)⍵}
-     
+
           Parse←{
               0=≢⍵:''
               bot←0=⍺
@@ -233,9 +233,9 @@
               ∨/1↓p:∊(p⊂⍺)∇¨p⊂⍵
               ⍵
           }
-     
+
           ErrIfEmpty←{⍵⊣'Array doesn''t have a prototype'⎕SIGNAL 11/⍨(0=≢⍵)}
-     
+
           SubParse←{
               ('})]'⍳⊃⌽⍵)≠('{(['⍳⊃⍵):'Bad bracketing'⎕SIGNAL 2
               (a w)←(1↓¯1∘↓)¨(⍺-1)⍵
@@ -244,9 +244,9 @@
               '('=⊃⍵:Paren{⍵,'⎕NS⍬'/⍨0=≢⍵}a Parse w ⍝ vector/empty ns
               ⍵ ⍝ dfn
           }
-     
+
           SysVar←(⎕C sysVars)∊⍨' '~¨⍨⎕C∘⊆
-     
+
           ParseLine←{
               c←⍵⍳':'
               1≥≢(c↓⍵)~' ':'Missing value'⎕SIGNAL 6
@@ -254,7 +254,7 @@
               (SysVar⍱¯1≠⎕NC)name:'Invalid name'⎕SIGNAL 2
               name(name,'←',⍺ Parse Over((c+1)↓⊢)⍵)
           }
-     
+
           Namespace←{
               p←(0=⍺)×SepMask ⍵
               (names assns)←↓⍉↑⍺ ParseLine EachNonempty Over(p Split)⍵
@@ -265,7 +265,7 @@
               names,←(0=≢names)/⊂''
               ∊'({'(assns,¨'⋄')quadAssns'⎕NS'('(, '∘,¨q,¨names,¨⊂q')')'}⍬)'
           }
-     
+
           Execute←{   ⍝ overcome LIMIT ERROR on more than 4096 parenthesised expressions
               ExecuteEach←{         ⍝ split at level-1 parentheses and execute each
                   l←(t=¯1)++\t←{1 ¯1 0['()'⍳⍵]}Unquot ⍵ ⍝ parenthesis type and level
@@ -281,10 +281,10 @@
               DEBUG:⍺ ExecuteEach ⍵           ⍝ force going through the hard code
               10::⍺ ExecuteEach ⍵ ⋄ ⍺⍎⍵       ⍝ attempt simple ⍎ and catch LIMIT ERROR
           }
-     
+
           w←'''[^'']*''' '⍝.*'⎕R'&' ''⊢w ⍝ strip comments
           w/⍨←{(∨\⍵)∧⌽∨\⌽⍵}33≤⎕UCS w     ⍝ strip leading/trailing non-printables
-     
+
           pl←ParenLev w
           (0≠⊢/pl)∨(∨/0>pl):'Unmatched brackets'⎕SIGNAL 2
           ∨/(pl=0)×SepMask w:'Multi-line input'⎕SIGNAL 11
@@ -355,8 +355,8 @@
           ∧/⍵(1∊⍷)¨⊂↑a:
           !#
       }
-     
-     
+
+
       :Section scalars
           {
               ⎕NULL
@@ -389,26 +389,26 @@
               '$'
               )
           }Is(⊂'<>'),'''"$'
-     
+
           {(42 ⋄ )}Is,42
-     
+
           {(42
               )}Is,42
-     
+
           {
               (1 2 3 'Hello' ⋄ 4 5 6 'World')
           }Is(1 2 3 'Hello')(4 5 6 'World')
-     
+
           {
               (1 2 3 'Hello'
               4 5 6 'World')
           }Is(1 2 3 'Hello')(4 5 6 'World')
-     
+
           {
               (0 1 ⋄ 2 3
               4 5 ⋄ 6 7)
           }Is↓4 2⍴⍳8
-     
+
           {
               ('Three'
               'Blind'
@@ -422,11 +422,11 @@
               ¯1('-' ⋄ )
               ]
           }Is 2 2⍴1 '' ¯1(,'-')
-     
+
           {[0 1 2
               3 4 5]
           }Is 2 3⍴⍳6
-     
+
           {[
               (
               'short'
@@ -438,30 +438,30 @@
               'longest test text'
               )]
           }Is⍪'short' 'longer text' 'longest test text'
-     
+
           {[ ⋄ 0 1 2 3]
           }Is⍉⍪⍳4
-     
+
           {[
               0 1 2 3
               ]
           }Is⍉⍪⍳4
-     
+
           {['Three'
               'Blind'
               'Mice']
           }Is 3 5⍴'ThreeBlindMice '
-     
+
           {[
               ('Three'
               'Blind'
               'Mice')
               ]
           }Is 1 3⍴'Three' 'Blind' 'Mice'
-     
+
           {[1 ⋄ ]
           }Is⍪1
-     
+
           {
               1 2[1 ⋄ ]
           }Is 1 2(⍪1)
@@ -471,18 +471,18 @@
               ([0 0 1
               1 0 1
               0 1 1]
-     
+
               [0 1 1
               1 1 0
               0 1 0]
-     
+
               [0 1 1 1
               1 1 1 0]
-     
+
               [0 1 1 0
               1 0 0 1
               0 1 1 0])
-     
+
           }Is Ed{
               _←⍉⍪0 0 1
               _⍪←1 0 1
@@ -501,7 +501,7 @@
               r,←⊂_
               r
           }⍬
-     
+
           {[0 'OK' ⋄ 1 'WS FULL' ⋄ 2 'SYNTAX ERROR' ⋄ 3 'INDEX ERROR' ⋄ 4 'RANK ERROR']
           }Is{
               e←⍉⍪0 'OK'
@@ -515,7 +515,7 @@
               (⊂1 2)'a'(⊂1 2)]
           }Is 2 3⍴'a'(⊂1 2)
       :EndSection
-     
+
       :Section High Rank
           {
               [[3
@@ -561,9 +561,9 @@
               ]
               ]
           }Is Ed 3 2 1 1⍴1 2 3 4 5 6
-     
+
       :EndSection
-     
+
       :Section Empty
           {
               ⍬
@@ -592,54 +592,54 @@
               0⌿⊂0⌿[0 ⋄ ]
           }Is 0⌿⊂⍪⍬
       :EndSection
-     
+
       :Section Namespace
           {
               ()
           }Is'{}'
-     
+
           {
               (
               )
           }Is'{}'
-     
+
           {
               ()()
           }Is'[{},{}]'
-     
+
 ⍝          {
 ⍝              (a:⍳n←3 ⋄ b:n*2)
 ⍝          }Is'{"a":[0,1,2],"b":9}'
-     
+
 ⍝          {
 ⍝              (p:{⍺+⍵}
 ⍝              m:{⍺-⍵}
 ⍝              s:,∘(,',')((,',')∘,)
 ⍝              o:⍣2)
 ⍝          }Is'p:{⍺+⍵}' 'm:{⍺-⍵}' 's:(,∘(' '))((' ')∘,)' 'o:⍣2'
-     
+
           {
               (v:(1 2 ⋄ 3))
           }Is'{"v":[[1,2],3]}'
-     
+
           {
               (v:(1 2
               3))
           }Is'{"v":[[1,2],3]}'
-     
+
           {
               (v:(1 2 ⋄ 3)
               )
           }Is'{"v":[[1,2],3]}'
-     
+
           {
               (
               ()
               )
           }Is'[{}]'
-     
+
           {(n:())}Is'{"n":{}}'
-     
+
       :EndSection
       r←1
     ∇
@@ -654,7 +654,7 @@
           ×⎕NC'⍺':Check a.⎕NR ⍺
           Check{⎕JSON⍣(326∊⎕DR¨∊⍵)⊢⍵}⍣(⍵≢⎕NULL)⊢a
       }
-     
+
       :Section scalars
           {
               'a'
@@ -671,28 +671,28 @@
       :EndSection
       :Section vectors
           {(42 ⋄ )}Is,42
-     
+
           {(42
               )}Is,42
-     
+
           {           ⍝ ⎕AV
               'Hello',(⎕UCS 0 8 10 13 32 12 6 7 27 9 9014 619),'%''⍺⍵_abcdefghijklmnopqrstuvwxyz',(⎕UCS 1 2),'¯.⍬0123456789',(⎕UCS 3 8866 165),'$£¢∆ABCDEFGHIJKLMNOPQRSTUVWXYZ',(⎕UCS 4 5 253 183 127),'⍙ÁÂÃÇÈÊËÌÍÎÏÐÒÓÔÕÙÚÛÝþãìðòõ{',(⎕UCS 8364),'}⊣⌷¨ÀÄÅÆ⍨ÉÑÖØÜßàáâäåæçèéêëíîïñ[/⌿\⍀<≤=≥>≠∨∧-+÷×?∊⍴~↑↓⍳○*⌈⌊∇∘(⊂⊃∩∪⊥⊤|;,⍱⍲⍒⍋⍉⌽⊖⍟⌹!⍕⍎⍫⍪≡≢óôöø"#',(⎕UCS 30 38 180 9496 9488 9484 9492 9532 9472 9500 9508 9524 9516 9474),'@ùúû^ü`∣¶:⍷¿¡⋄←→⍝)]',(⎕UCS 31 160),'§⎕⍞⍣'
           }Is'Hello',⎕AV
-     
+
           {
               (1 2 3 'Hello' ⋄ 4 5 6 'World')
           }Is(1 2 3 'Hello')(4 5 6 'World')
-     
+
           {
               (1 2 3 'Hello'
               4 5 6 'World')
           }Is(1 2 3 'Hello')(4 5 6 'World')
-     
+
           {
               (0 1 ⋄ 2 3
               4 5 ⋄ 6 7)
           }Is↓4 2⍴⍳8
-     
+
           {
               ('Three'
               'Blind'
@@ -703,52 +703,52 @@
           {[0 1 2
               3 4 5]
           }Is 2 3⍴⍳6
-     
+
           {[ ⋄ 0 1 2 3]
           }Is⍉⍪⍳4
-     
+
           {[
               0 1 2 3
               ]
           }Is⍉⍪⍳4
-     
+
           {['Three'
               'Blind'
               'Mice']
           }Is 3 5⍴'ThreeBlindMice '
-     
+
           {[1 ⋄ ]
           }Is⍪1
-     
+
           {
               1 2[1 ⋄ ]
           }Is 1 2(⍪1)
-     
+
           {
               ['[' ⋄ ]
           }Is 1 1⍴'['
           {
               ['(' ⋄ ]
           }Is 1 1⍴'('   ⍝ link issue #271
-     
+
       :EndSection
       :Section Combo
           {
               ([0 0 1
               1 0 1
               0 1 1]
-     
+
               [0 1 1
               1 1 0
               0 1 0]
-     
+
               [0 1 1 1
               1 1 1 0]
-     
+
               [0 1 1 0
               1 0 0 1
               0 1 1 0])
-     
+
           }Is Ed{
               _←⍉⍪0 0 1
               _⍪←1 0 1
@@ -767,7 +767,7 @@
               r,←⊂_
               r
           }⍬
-     
+
           {[0 'OK' ⋄ 1 'WS FULL' ⋄ 2 'SYNTAX ERROR' ⋄ 3 'INDEX ERROR' ⋄ 4 'RANK ERROR']
           }Is{
               e←⍉⍪0 'OK'
@@ -781,7 +781,7 @@
               (⊂1 2)'a'(⊂1 2)]
           }Is 2 3⍴'a'(⊂1 2)
       :EndSection
-     
+
       :Section High Rank
           {
               [[3
@@ -790,7 +790,7 @@
               2 8]]
           }Is Ed 2 2 3⍴3 0 0 1 5 9 2 7 1 2 8 0
       :EndSection
-     
+
       :Section Empty
           {
               ⍬
@@ -819,52 +819,52 @@
               0⌿⊂0⌿[0 ⋄ ]
           }Is 0⌿⊂⍪⍬
       :EndSection
-     
+
       :Section Namespace
           {
               ()
           }Is'{}'
-     
+
           {
               (
               )
           }Is'{}'
-     
+
           {
               ()()
           }Is'[{},{}]'
-     
+
 ⍝          {
 ⍝              (a:⍳n←3 ⋄ b:n*2)
 ⍝          }Is'{"a":[0,1,2],"b":9}'
-     
+
           'p' 'm'{
               (p:{⍺+⍵}
               m:{⍺-⍵})
           }Is¨'{⍺+⍵}' '{⍺-⍵}'
-     
+
           {
               (v:(1 2 ⋄ 3))
           }Is'{"v":[[1,2],3]}'
-     
+
           {
               (v:(1 2
               3))
           }Is'{"v":[[1,2],3]}'
-     
+
           {
               (v:(1 2 ⋄ 3)
               )
           }Is'{"v":[[1,2],3]}'
-     
+
           {
               (
               ()
               )
           }Is'[{}]'
-     
+
           {(n:())}Is'{"n":{}}'
-     
+
       :EndSection
       r←1
     ∇
@@ -881,7 +881,7 @@
           9∊{⊃⎕NC'⍵'}¨∊⍵:(Serialise ⍵)Check Serialise Deserialise Serialise ⍵
           ⍵ Check Deserialise Serialise ⍵
       }
-     
+
       :Section numbers
           ns←⎕NS ⍬
           :For ns.⎕FR :In 645 1287
@@ -891,8 +891,8 @@
               Check ns.(0.1J0.1)
           :EndFor
       :EndSection
-     
-     
+
+
       :Section scalars
           Is'a'
           Is 42
@@ -942,7 +942,7 @@
               r,←⊂_
               r
           }⍬
-     
+
           Is{
               e←⍉⍪0 'OK'
               e⍪←1 'WS FULL'
@@ -958,19 +958,19 @@
           Is'ABC'(,⊂⊂'')
           Is'A'(,⊂⊂'')
       :EndSection
-     
+
       :Section High Rank
           Is 1 1 2 3⍴⍳6     ⍝ issue #254
           Is 3 2 1 1⍴⍳6     ⍝ issue #254
           Is 2 3 4 5⍴⍳120   ⍝ issue #254
           Is⊂[3 4 5]⎕AV[?1 2 3 1 5 6⍴256]      ⍝ issue #254
       :EndSection
-     
+
       :Section Large Arrays                  ⍝ (more than 4096 constants) - issue #255
           Is⊂[2 3]?50 100 2 3⍴100              ⍝ Numeric is straightforward
           Is⊂[3 4 5]⎕AV[?50 10 10 1 2 3⍴256]   ⍝ Text gets functional headers produced by Parse
       :EndSection
-     
+
       :Section Empty
           Is ⍬
           Is,⊂⍬
@@ -982,7 +982,7 @@
           Is 0⌿⊂⍉⍪⍬
           Is 0⌿⊂⍪⍬
       :EndSection
-     
+
       :Section Namespace
           Is ⎕JSON'{}'
           Is ⎕JSON'{}'
@@ -1000,7 +1000,7 @@
           Is ⎕JSON'[{}]'
           Is ⎕JSON'{"n":{}}'
       :EndSection
-     
+
       :Section Deep arrays
           arrays←⎕NULL((⎕NS ⍬).(⎕THIS⊣var←(idiom←{⍵[⍋⍵]})(foo←{,⍵})123))(?256⍴0)(⎕AV[256?256])
           shapes←⍬ 0 1 256(0 0)(0 256)(256 0)(16 16)

--- a/StartupSession/Dyalog/Config.apln
+++ b/StartupSession/Dyalog/Config.apln
@@ -2,7 +2,7 @@
 
     ∇ dir←AllVersions;base;w;x;pat ⍝ report current effective path to version agnostic user settings dir
       x←~w←⊃'Windows'⍷⊃# ⎕WG'APLVersion'
-     
+
       pat←'[DYALOG_CONFIG_ALLVERSIONS]' '$XDG_CONFIG_HOME/dyalog/apl' '$HOME/.config/dyalog/apl' '%APPDATA%\dyalog\apl'
       dir←⎕SE.Dyalog.Utils.ExpandConfig 1 x x w/pat
       dir⊃⍤~←⊂''
@@ -10,11 +10,11 @@
 
     ∇ dir←ThisVersion;x;w;os;ver;pat ⍝ report current effective path to version specific user settings dir
       x←~w←⊃'Windows'⍷⊃(os ver)←2↑# ⎕WG'APLVersion'
-     
+
       ver(∊2↑≠⊆⊣)←'.'           ⍝ maj.min
       ver,←'UC'/⍨80 82=⎕DR''    ⍝ U[nicode]/C[lassic]
       ver,←¯2↑'32',(⍳∘'-'↓⊢)os  ⍝ -bits
-     
+
       pat←'[DYALOG_CONFIG_THISVERSION]',⍥⊆'$XDG_CONFIG_HOME/dyalog/apl/' '$HOME/.config/dyalog/apl/' '%APPDATA%\dyalog\apl\',¨⊂ver
       dir←⎕SE.Dyalog.Utils.ExpandConfig 1 x x w/pat
       dir⊃⍤~←⊂''
@@ -25,21 +25,21 @@
           ⍝ scope(s): 1=ThisVersion, 2=AllVersions (default), 3=Both
           ⍝ omit left argument (or use ⎕NULL) to delete configuration
           ⍝ ⎕A Set 'user-alphabet'
-     
+
           0::⎕SIGNAL⊂⎕DMX.(('EN'EN)('EM'EM)('Message'(OSError{⍵,2⌽(×≢⊃⍬⍴2⌽⍺,⊂'')/'") ("',⊃⍬⍴2⌽⍺}Message)))  ⍝ bubble errors
-     
+
           rarg←⊂⍣(''≡0⌿⍵)⊢⍵  ⍝ enclose if simple string
           2<≢rarg:⎕SIGNAL⊂('EN' 11)('Message' 'Argument must be ID optionally followed by scope')
           (id scopes)←rarg,2⍴⍨1=≢rarg  ⍝ default is 2
-     
+
           r←⎕NULL Get id scopes
-     
+
           PutJSON←{  ⍝ Write verbose JSON of value ⍺ to file ⍵ making any dirs needed
               ⎕NULL≡⍺:1 ⎕NDELETE ⍵
               _←3 ⎕MKDIR⊃⎕NPARTS ⍵
               ⍵ 1 ⎕NPUT⍨1 ⎕JSON⍠'Compact' 0⊢⍺
           }
-     
+
           ⍺←⎕NULL
           paths←AllVersions ThisVersion/⍨2 2⊤+/∪scopes
           paths,¨←⊂'/',id,'.json'
@@ -50,20 +50,20 @@
           ⍝ [defaultVal] Get id [scope(s)]
           ⍝ scope(s): 1=ThisVersion, 2=AllVersions, 3=Merge (default)
           ⍝ multiple scopes indicates priority
-     
+
           0::⎕SIGNAL⊂⎕DMX.(('EN'EN)('EM'EM)('Message'(OSError{⍵,2⌽(×≢⊃⍬⍴2⌽⍺,⊂'')/'") ("',⊃⍬⍴2⌽⍺}Message)))  ⍝ bubble errors
-     
+
           non←⎕NS ⍬  ⍝ unique non-value without prototype
           ⍺←non
-     
+
           rarg←⊂⍣(''≡0⌿⍵)⊢⍵  ⍝ enclose if simple string
           2<≢rarg:⎕SIGNAL⊂('EN' 11)('Message' 'Argument must be ID optionally followed by scope')
           (id scopes)←rarg,3⍴⍨1=≢rarg  ⍝ default is 3
-     
+
           ⍬≡'^[0-9_a-z]+-[0-9_a-z]+$'⎕S 3⊢id:⎕SIGNAL⊂('EN' 11)('Message' 'ID must be {vendor}-{subject} of digits/lowercase/underscore')
-     
+
           0∊scopes∊1 2 3:⎕SIGNAL⊂('EN' 11)('Message' 'Scope must be zero or more of 1 2 3')
-     
+
           GetJSON5←{  ⍝ Read JSON5 from file ⍵ establishing namespace values in ⍺
               11::⎕SIGNAL⊂('EN' 11)('Message'(⍵,⎕DMX.Message(⊣↓⍨¯1+⍳)':'))  ⍝ bad JSON
               ⎕NEXISTS ⍵:0 ⍺.⎕JSON⍠'Dialect' 'JSON5'⊃⎕NGET ⍵
@@ -71,17 +71,17 @@
           }
           paths←AllVersions ThisVersion,¨⊂'/',id,'.json'
           (va vs)←(⊃⎕RSI)GetJSON5¨paths
-     
+
           Merge←{(va vs)←⍺ ⍵  ⍝ merge namespace values or return version ⍵ if not both ⍺ and ⍵ are namespaces
               vars←2=40 ⎕ATX'vs' 'va'
               ∨/vars,vs va∊non:⊃vs va ⍺/⍨vars,1  ⍝ return first good
               ⊃(⎕NS ⍬)⎕NS¨va vs  ⍝ two namespaces: merge
           }
           vm←va Merge vs
-     
+
           msg←'No "',id,'" data available',' for this version' ' for all versions' ''⊃⍨3⌊3@(~×)+/∪scopes
           16::⎕SIGNAL⊂('EN' 6)('Message'msg)
-     
+
           ⊃non~⍨vs va vm[scopes],⊂⍺
       }
 

--- a/StartupSession/Dyalog/Utils.apln
+++ b/StartupSession/Dyalog/Utils.apln
@@ -66,15 +66,15 @@
     ⍝         origin>0 and params is nested:  matrix of   (name source value) rows
     ⍝         origin=0 and params is '' or ⍬: matrix of   (name        value) rows
     ⍝         origin>1 and params is '' or ⍬: matrix of   (name source value) rows
-     
+
       :If 900⌶⍬ ⋄ origin←0 ⋄ :EndIf ⍝ default left
       (os ver)←2↑# ⎕WG'APLVersion'
-     
+
       ErrIf←⎕SIGNAL{(⌈/⍵)⍴⊂('EN' 11)('Message'⍺)}
       'requires 18.0 or higher'ErrIf 18>2 1⊃'.'⎕VFI ver
       'right argument (parameters) must be ⍬ character vector(s) or ⍬ (all)'ErrIf(3∘≤∘|∘≡,''⍬∘∊)param
       'left argument (show origin) must be 0 (none), 1 (short), or 2 (long)'ErrIf~0 1 2∊⍨⊂origin
-     
+
       :If ⍬''∊⍨⊂param ⍝ all
           :Trap 0
               env←⎕SH cmd←'env' 'set'⊃⍨1+'Windows'≡7↑os
@@ -83,15 +83,15 @@
           :EndTrap
           cfg←⊣/161⌶0 ⍝ unofficial: config file contents
           cla←2 ⎕NQ'.' 'GetCommandLineArgs'
-     
+
           OnlySet←{⍵/⍨'='∊¨⍵↑¨⍨⌊/⍵∘.⍳'''"'} ⍝ only name=value args
           Names←{⍵↑⍨¯1+⍵⍳'='}¨              ⍝ names up until "="
           all←{⍵[⍋⍵]}∪1 ⎕C cfg,Names env,OnlySet cla
-     
+
           r←{⍵⌿⍨×≢¨⊢/⍵}origin Config all ⍝ filter out empty vars
       :ElseIf 1≥|≡param ⍝ one
           (val loc)←160⌶param ⍝ unofficial: value and origin of configuration parameter
-     
+
           Adjust←{ ⍝ Expand or abbreviate origin
               (short long)←⍺=⍳2
               short∧'Environment variable'≡⍵:'Env var'
@@ -126,10 +126,10 @@
           ⍝ Handles ~ and ~+ and ~- under UX only
           ⍝ Use \ or ^ or ` to escape patterns
           ⍝ optionally restrict pattern type and escape using left argument as per below
-     
+
           ⍝ For user's home dir, use ⎕SE.SALTUtils.USERDIR
           0::⎕SIGNAL⊂⎕DMX.(('EN'EN)('Message'Message))
-     
+
           ⍺←0
           type←⎕C⊂⍺
           ps←type∊'ps' 'powershell' 'psh'
@@ -137,7 +137,7 @@
           salt←type∊'salt' 'dyalog'
           posix←type∊'posix' 'linux' 'unix' 'ux' 'pi' 'aix' 'mac' 'macos' 'qshell' 'rc'
           posix∨←'sh'≡¯2↑⊃type
-     
+
           Esc←'[%\\&]'⎕R'\\&'
           Untilde←{
               ⎕SE.SALTUtils.WIN>posix:⍵
@@ -146,13 +146,13 @@
               '(\W|^)~\+()' '(\W|^)~-()' '(\W|^)~(\W|$)'⎕R subs⍠'UCP' 1⊢⍵
           }
           Sub←{⍵⍵ ⎕R(⍺⍺{⍵.PatternNum:⍺⍺(Config ¯1↓↓)⍵.Match ⋄ ⊢/⍵.Match})⊢⍵} ⍝ chop leading ⍺ chars
-     
+
           ps:6 Sub'`[$`]' '\$\{env:([^}]+)}'⊢'\$env:([\pL_]\w*)'⎕R'${env:\1}'⊢⍵
           cmd:1 Sub'\^[%^]' '%([^%]+)%'⊢⍵
           salt:1 Sub']' '\[([^]]+)]'⊢⍵
           posix:2 Sub'\\[$\\]' '\$\{([^}]+)}'⊢'\$([\pL_]\w*)'⎕R'${\1}'⍠'UCP' 1 Untilde ⍵
           0≢⍺:⎕SIGNAL⊂('EN' 11)('Message' 'Left argument must be environment type (ps/cmd/salt/ux/etc.)')
-     
+
           bracked←'\$env:([\pL_]\w*)' '\$\{env:([^}]+)}' '\$([\pL_]\w*)' '\$\{([^}]+)}' '\[([^]]+)]' '%([^%]+)%'⎕R'[\1]'⍠'UCP' 1 Untilde ⍵
           1 Sub'\\[$\\]|\^[%^]|`[$`]' '\[([^]]+)]'⊢bracked
       }
@@ -191,12 +191,12 @@
       :Else
           old←⊃⎕SH'pwd'
       :EndIf
-     
+
       :If ~0∊⍴new         ⍝ change directory
           :If ~force
               ⎕SIGNAL(×≢relativeTies)/⊂('EN' 24)('Message'('Some files (',('.relativeTies',⍨⍕⎕THIS),') ⎕NTIEd/⎕FTIEd with relative names (use left argument 1 to ignore)'))
           :EndIf
-     
+
           :If 'Win'≡OS
              ⍝ chdir returns a single int: 1=ok
               ('Unable to change directory: ',new,': Invalid directory')⎕SIGNAL(chdir⊂new)↓22
@@ -286,17 +286,17 @@
       }
 
       drvSrc←{⎕ML←1                              ⍝ Linear representation of fnop named ⍵.
-     
+
           src←⍺.⎕CR ⍵                             ⍝ source.
-     
+
           qt←''''                                 ⍝ single quote
           qtd←{qt,((1+⍵=qt)/⍵),qt}                ⍝ quoted.
-     
+
           sepr←{                                  ⍝ adjacent arrays.
               qt∨.≠(⊃⌽⍺),⊃⍵:⍺,⍵                   ⍝ adjacent quoted vectors
               ⍺,' ',⍵                             ⍝ blank-separated.
           }
-     
+
           array←{
               0=≡⍵:scalar ⍵                       ⍝ simple scalar
               1 1≡(≡⍵),⍴⍴⍵:vector ⍵               ⍝ simple vector.
@@ -305,12 +305,12 @@
               1=⍴⍴⍵:⊃sepr/⊃,/(~ischar¨⍵)p∘∇¨⍵     ⍝ nested vector
               1 repObj ⍵                          ⍝ FIXME
           }
-     
+
           scalar←{                                ⍝ scalar value
               ischar ⍵:qtd ⍵                      ⍝ char
               ⍕,⍵                                 ⍝ number or ref
           }
-     
+
           vector←{                                ⍝ simple vector.
               0=⍴⍵:⊃(ischar ⍵)⌽'⍬'(qtd'')         ⍝ null: '' or ⍬.
               1=⍴⍵:1 p scalar⊃⍵                   ⍝ single vector → (,0)
@@ -318,22 +318,22 @@
               ∧/ischar¨⍵:qtd ⍵                    ⍝ simple char char vec:
               1 repObj ⍵                          ⍝ FIXME
           }
-     
+
           uni←80=⎕DR''                            ⍝ unicode version
-     
+
           pf0←'+-×÷⌊⌈|*⍟<≤=≥>≠∨∧⍱⍲!?~○'           ⍝ scalar fns.
           pf1←'⌷/⌿\⍀∊⍴↑↓⍳⊂⊃∩∪⊣⊢⊥⊤,⍒⍋⍉⌽⊖⌹⍕⍎⍪≡≢⍷'   ⍝ other fns.
           pfu←⎕UCS uni/8838 9080                  ⍝ where, condencl
           pfns←pf0,pf1,pfu                        ⍝ primitive fns.
-     
+
           kvr←⎕UCS uni/9000+16 18 56 60           ⍝ key, stencil, variant, rank
           pops←'/\⌿⍀.¨∘⍨&⍣[@⌶',kvr                ⍝ primitive ops.
-     
+
           ispfn←{(⊂,⍵)∊,¨pfns}
           ispop←{(⊂,⍵)∊,¨pops}
           isnum←{0≡⊃0⍴⍵}
           ischar←{' '≡⊃0⍴⍵}
-     
+
           isdfn←{             ⍝ probably the ⎕cr of a dfn
               1≠≡⍵:0          ⍝ too deep
               ~(⍴⍴⍵)∊2 1:0    ⍝ not a matrix (or vector)
@@ -342,7 +342,7 @@
               '{'=⊃⍵:1        ⍝ starts with {...
               1∊'←{'⍷⍵        ⍝ starts with name←{
           }
-     
+
           isderv←{            ⍝ probably the ⎕cr of a derived fn.
               ~1=⍴⍴⍵:0        ⍝ not a vector.
               ~(⍴⍵)∊2,⍺+2:0   ⍝ not monadic or dyadic operator.
@@ -351,24 +351,24 @@
               dop←isdfn op    ⍝ D-operator.
               pop∨dop         ⍝ operator.
           }
-     
+
           istrain←{           ⍝ probably the ⎕cr of a fn train.
               ~1=⍴⍴⍵:0        ⍝ not a vector.
               ~(⍴⍵)∊2 3:0     ⍝ not 2- or 3-train
               ∧/isfn¨¯2↑⍵     ⍝ last two tines are fns
           }
-     
+
           issysfn←{           ⍝ is a ⎕fn?
               1≠≡⍵:0          ⍝ too deep
               1≠⍴⍴⍵:0         ⍝ not a vector
               '⎕'≠⊃⍵:0        ⍝ doesn't start '⎕...'
               1               ⍝ ok.
           }
-     
+
           isfn←{(isdfn ⍵)∨(ispfn ⍵)∨(istrain ⍵)∨(0∘isderv ⍵)∨(1∘isderv ⍵)∨issysfn ⍵}
-     
+
           p←{⍺=0:⍵ ⋄ '(',⍵,')'}   ⍝ ⍺-conditional parens.
-     
+
           def←{
               ispfn ⍵:⍵                                                ⍝ primitive fn.
               ispop ⍵:⍵                                                ⍝ primitive oper.
@@ -383,7 +383,7 @@
               issysfn ⍵:⍵                                              ⍝ system fn.
               array ⍵
           }
-     
+
           ,↑0 def src
       }
 
@@ -394,15 +394,15 @@
       }
 
       disp←{⎕IO ⎕ML←0 1                           ⍝ Boxed sketch of nested array.
-     
+
           ⍺←⍬ ⋄ opts←⍺,(⍴,⍺)↓1 1 1 0 ⎕PP          ⍝ option defaults:
           dec bch ctd sep ⎕PP←5↑opts              ⍝ decor, smooth, centred, separate pp.
-     
+
           ul uc ur←bch⊃⌽'┌┬┐' '.'                 ⍝ upper──┐ ┌───left
           ml mc mr←bch⊃⌽'├┼┤' '|+|'               ⍝ middle─┼×┼─centre
           ll lc lr←bch⊃⌽'└┴┘' ''''                ⍝ lower──┘ └──right
           vt hz←bch⊃⌽'│─' '|-'                    ⍝ vertical and horizontal.
-     
+
           box←{                                   ⍝ Recursive boxing of nested array.
               isor ⍵:⎕FMT⊂⍵                       ⍝ ⎕or: '∇name'.
               1=≡,⍵:dec open ⎕PP ∆FMT1 dec open ⍵     ⍝ simple array: format.
@@ -412,7 +412,7 @@
               subs←aligned ∇¨mat                  ⍝ aligned boxed subarrays.
               (≢⍴⍵)gaps ⍵ plane subs              ⍝ collection into single plane.
           }
-     
+
           aligned←{                               ⍝ Alignment and centring.
               rows cols←sepr⍴¨⍵                   ⍝ subarray dimensions.
               sizes←(⌈/rows)∘.,⌈⌿cols             ⍝ aligned subarray sizes.
@@ -420,7 +420,7 @@
               v h←sepr⌈0.5×↑(⍴¨⍵)-sizes           ⍝ vertical and horizontal rotation.
               v⊖¨h⌽¨sizes↑¨⍵                      ⍝ centred aligned subarrays.
           }
-     
+
           gaps←{                                  ⍝ Gap-separated sub-planes.
               sep≤⍺≤2:⍵                           ⍝ not separating: done.
               subs←(⍺-1)∇¨⍵                       ⍝ sub-hyperplanes.
@@ -428,52 +428,52 @@
               fill←(⍺ width-3 0)⍴' '              ⍝ inter-plane gap.
               ↑{⍺⍪fill⍪⍵}/1 open subs             ⍝ gap-separated planes.
           }
-     
+
           plane←{                                 ⍝ Boxed rank-2 plane.
               sep∧2<⍴⍴⍺:⍺ join ⍵                  ⍝ gap-separated sub-planes.
               odec←(dec shape ⍺)outer ⍵           ⍝ outer type and shape decoration.
               idec←inner ⍺                        ⍝ inner type and shape decorations.
               (odec,idec)collect ⍵                ⍝ collected, formatted subarrays.
           }
-     
+
           join←{                                  ⍝ Join of gap-separated sub-planes.
               sep←(≢⍵)÷1⌈≢⍺                       ⍝ sub plane separation.
               split←(0=sep|⍳≢⍵)⊂[0]⍵              ⍝ separation along first axis.
               (⊂⍤¯1⊢⍺)plane¨split                 ⍝ sub-plane join.
           }
-     
+
           outer←{                                 ⍝ Outer decoration.
               sizes←1 0{⊃↓(⍉⍣⍺)⍵}¨sepr⍴¨⍵         ⍝ row and col sizes of subarrays.
               sides←sizes/¨¨vt hz                 ⍝ vert and horiz cell sides.
               bords←dec↓¨ml uc glue¨sides         ⍝ joined up outer borders.
               ↑,¨/(ul'')⍺ bords(ll ur)            ⍝ vertical and horizontal borders.
           }
-     
+
           inner←{                                 ⍝ Inner subarray decorations.
               deco←{(type ⍵),1 shape ⍵}           ⍝ type and shape decorators.
               sepr deco¨matr dec open ⍵           ⍝ decorators: tt vv hh .
           }
-     
+
           collect←{                               ⍝ Collected subarrays.
               lft top tt vv hh←⍺                  ⍝ array and subarray decorations.
               cells←vv right 1 open tt hh lower ⍵ ⍝ cells boxed right and below.
               boxes←(dec∨0∊⍴⍵)open cells          ⍝ opened to avoid ,/⍬ problem.
               lft,top⍪↑⍪⌿,/boxes                  ⍝ completed collection.
           }
-     
+
           right←{                                 ⍝ Border right each subarray.
               types←2⊥¨(⍳⍴⍵)=⊂¯1+⍴⍵               ⍝ right border lower corner types.
               chars←mc mr lc lr[types]            ⍝    ..     ..      ..      chars.
               rgt←{⍵,(-≢⍵)↑(≢⍵)1 1/vt,⍺}          ⍝ form right border.
               ((matr 1 open ⍺),¨chars)rgt¨⍵       ⍝ cells bordered right.
           }
-     
+
           lower←{                                 ⍝ Border below each subarray.
               bot←{⍵⍪(-1⊃⍴⍵)↑⍺ split ⍵}           ⍝ lower border.
               split←{((¯2+1⊃⍴⍵)/hz)glue ⍺}        ⍝ decorators split with horiz line.
               (matr↑,¨/⍺)bot¨matr ⍵               ⍝ cells bordered below.
           }
-     
+
           type←{                                  ⍝ Type decoration char.
               dec<|≡⍵:hz                          ⍝ nested: '─'
               isor ⍵:'∇'                          ⍝ ⎕or:    '∇'
@@ -484,7 +484,7 @@
               0=≡⍵:sst ⍵                          ⍝ simple scalar: type.
               {(1=⍴⍵)⊃'+'⍵}∪,sst¨dec open ⍵       ⍝ array: mixed or uniform type.
           }
-     
+
           shape←{                                 ⍝ Row and column shape decorators.
               dec≤0=⍴⍴⍵:⍺/¨vt hz                  ⍝ no decoration or scalar.
               cols←(×¯1↑⍴⍵)⊃'⊖→'                  ⍝ zero or more cols.
@@ -492,13 +492,13 @@
               rows←(¯1+3⌊⍴⍴⍵)⊃vt rsig'⍒'          ⍝ high rank decorator overrides.
               rows cols                           ⍝ shape decorators.
           }
-     
+
           matr←{↑,↓⍵}                             ⍝ matrix from non-scalar array.
           sepr←{+/¨1⊂↑⍵}                          ⍝ vec-of-mats from mat-of-vecs.
           open←{16::(1⌈⍴⍵)⍴⊂'[ref]' ⋄ (⍺⌈⍴⍵)⍴⍵}   ⍝ stretched to expose nulls.
           isor←{1 ⍬≡(≡⍵)(⍴⍵)}                     ⍝ is ⎕or of object?
           glue←{0=⍴⍵:⍵ ⋄ ↑⍺{⍺,⍺⍺,⍵}/⍵}            ⍝ ⍵ interspersed with ⍺s.
-     
+
           isor ⍵:⎕FMT⊂⍵                           ⍝ simple ⎕OR: done.
           1=≡,⍵:⎕PP ∆FMT1 ⍵                           ⍝ simple array: done.
           box ⍵                                   ⍝ recursive boxing of array.
@@ -507,9 +507,9 @@
       display←{⎕IO ⎕ML←0                              ⍝ Boxed display of array.
           ⍺←⍬ ⋄ ch ⎕PP←2↑⍺,(⍴,⍺)↓1 ⎕PP                ⍝ default chars and precision
           chars←ch⊃'..''''|-' '┌┐└┘│─'                ⍝ ⍺: 0-clunky, 1-smooth.
-     
+
           tl tr bl br vt hz←chars                     ⍝ Top left, top right, ...
-     
+
           box←{                                       ⍝ Box with type and axes.
               vrt hrz←(¯1+⍴⍵)⍴¨vt hz                  ⍝ Vert. and horiz. lines.
               top←(hz,'⊖→')[¯1↑⍺],hrz                 ⍝ Upper border with axis.
@@ -519,7 +519,7 @@
               lft←⍉tl,(↑lax),bl                       ⍝ ... and corners.
               lft,(top⍪⍵⍪bot),rgt                     ⍝ Fully boxed array.
           }
-     
+
           deco←{⍺←type open ⍵ ⋄ ⍺,axes ⍵}             ⍝ Type and axes vector.
           axes←{(-2⌈⍴⍴⍵)↑1+×⍴⍵}                       ⍝ Array axis types.
           open←{16::(1⌈⍴⍵)⍴⊂'[ref]' ⋄ (1⌈⍴⍵)⍴⍵}       ⍝ Expose null axes.
@@ -527,7 +527,7 @@
           type←{{(1=⍴⍵)⊃'+'⍵}∪,char¨⍵}                ⍝ Simple array type.
           char←{⍬≡⍴⍵:hz ⋄ (⊃⍵∊'¯',⎕D)⊃'#~'}∘⍕         ⍝ Simple scalar type.
           line←{(6≠10|⎕DR' '⍵)⊃' -'}                  ⍝ underline for atom.
-     
+
           {                                           ⍝ Recursively box arrays:
               0=≡⍵:' '⍪(open ⎕FMT ⍵)⍪line ⍵           ⍝ Simple scalar.
               1 ⍬≡(≡⍵)(⍴⍵):'∇' 0 0 box ⎕FMT ⍵         ⍝ Object rep: ⎕OR.
@@ -546,7 +546,7 @@
 ⍝ Support for ]defs and ]boxing:
 
       nabs←{                              ⍝ Name abstraction:
-     
+
           subs←{                          ⍝ substitution of ⍵-names in ⍺-defns
               dfns←(⊃∘(⊃⌽)¨⍺)∊'{'         ⍝ mask of ⍺'s dfns
               vars←(⊃¨1↓¨⍺)∊2             ⍝ mask of ⍺'s vars
@@ -560,7 +560,7 @@
               zipd←{↓⍉↑⍺⍺↓⍉↑⍵}            ⍝ under zipping: [N K D] ←→ [N][K][D]
               sub1 foldl∘libs zipd srch ⍺ ⍝ largest-to-smallest search of lib defns
           }                               ⍝ :: [N K D] ← [N K D] ∇ [N K D]
-     
+
           sub1←{                          ⍝ defns ⍺ with name of library defn ⍵
               (Ns Ks Ds)(N K D)←⍺ ⍵       ⍝ accumulated defns, next library defn
               depth←|≡K                   ⍝ depth of kind-tree of sought item
@@ -572,17 +572,17 @@
               srch←trav¨@{~Ns∊⊂N}         ⍝ search of all but self :: [K D] ← ∇ [K D]
               (⊂Ns),↓⍉↑srch↓⍉↑Ks Ds       ⍝ name replacement
           }                               ⍝ :: [N][K][D] ← [N][K][D] ∇ N K D
-     
+
           uvals←{                         ⍝ mask of non-duplicated items
               grps←⊢∘⊂⌸⍵                  ⍝ value groups
               uniqs←∊(1=≢¨grps)/grps      ⍝ indices of unique values
               (⍳≢⍵)∊uniqs                 ⍝ non-duplicated items
           }                               ⍝ :: [?] ← ∇ [⍺]
-     
+
           curried←{1 0≡(|⊃⌽⍵)∊4}          ⍝ is curried: lft(dop rgt)?
           join←{l(d r)←⍵ ⋄ l d r}         ⍝ rejoining:  lft(dop rgt) → lft dop rgt
           uncurry←curried currying join   ⍝ reversion to triples for derived fns
-     
+
           kd←{0=≡⍵:⍵ ⋄ 3+4≡⊃⍵}            ⍝ kind from kind-tree
           nkd0←{1↓(⊂'' 0 ⍬),⍵}            ⍝ explicit prototypical item
           kinds←(⍺⍺>1 0 0 1)/2 3 4 9      ⍝ ⍺⍺: 0:none, 1:3 4, 2:2 3 4 9
@@ -590,7 +590,7 @@
           ⍺←⊃¨(3 4,(⍺⍺>1)/2 9)from ⍵      ⍝ default all names
           nkds←nkd0 ⍵[(⊃¨⍵)⍳(,¨⊆⍺)∩⊃¨⍵]   ⍝ subject NKDs
           uncurry¨nkds subs kinds from ⍵  ⍝ with names for values
-     
+
     ⍝ :: [N K D] ← [N](A ∇∇)[N K D] ⍝ name-abstraction:
     ⍝ N := ⍞                        ⍝   Name: char vector
     ⍝ K := 2 | 3 | 4 | 9 | [K]      ⍝   Kind-tree: nested kinds
@@ -599,7 +599,7 @@
       }
 
       nkds←{                              ⍝ (Name Kind Defn)-tuples
-     
+
           defs←{                          ⍝ defns from space ⍵
               Ns←~∘' '¨↓⍵.⎕NL 2 3 4 9     ⍝ all names
               Ks←⍵.(183⌶)¨Ns              ⍝ unofficial: all kind-trees
@@ -609,7 +609,7 @@
               Ds←v@{(kd¨Ks)∊2 9}⊢ds       ⍝ all definitions
               ↓⍉↑Ns Ks Ds                 ⍝ names kind-trees defns
           }                               ⍝ :: [N K D] ← ∇ S
-     
+
           prep←{                          ⍝ preparation of ⎕cr forms
               (⊂⍺)∊0 2 9:⍵                ⍝ array operand: ignore
               1 1≡(≡⍵),⍴⍵:⊃⍵              ⍝ named primitive fn: disclose of 1-vector
@@ -623,13 +623,13 @@
                   1↓,(,∨\named)/⍵         ⍝ without 'name←'
               }⍵                          ⍝ for definition ⍵
           }                               ⍝ :: D ← K ∇ D
-     
+
           derived←{0 1 0≡⍵∊4}             ⍝ is derived?: lft dop rgt
           sepr←{l d r←⍵ ⋄ l(d r)}         ⍝ separation: lft dop rgt → lft(dop rgt)
           curry←derived currying sepr     ⍝ currying of dyadic derived fns
-     
+
           curry¨defs ⍵                    ⍝ (name kinds defn)-tuples
-     
+
     ⍝   :: [N K D] ← ∇ space        ⍝ Name Kind Defn
     ⍝ N := ⍞                        ⍝   Name: char vector
     ⍝ K := 2 | 3 | 4 | 9 | [K]      ⍝   Kind-tree: nested kinds
@@ -645,9 +645,9 @@
       }
 
       expr←{                                  ⍝ Linear representation of expression ⍵.
-     
+
           ⍺←1 0 ⋄ N P←⍺,(≢⍺)↓0 0              ⍝ N:names P:parenthesised
-     
+
           xpr←{K←|⊃k D←⍵                      ⍝ expression from nested defns
               cfmt←⎕SE.Dyalog.Utils.repObj    ⍝ char format
               (⊂K)∊2 9:⍺ cfmt⍣(k>0)⊢D         ⍝ array component
@@ -659,20 +659,20 @@
               pns←(0≠≡¨¯1↓K),0                ⍝ leading non-simple tines
               ⍺ pp⊃join/(P∨pns∧exp)∇¨↓⍉↑⍵     ⍝ joined with parentheses ⍺
           }                                   ⍝ :: ⍞ ← ? ∇ K D
-     
+
           join←({(0≤⎕NC⍪⍵)/⍵}⎕AV~'⍺⍵∇'){      ⍝ join of expressions
               adj←(⊢/⊣),(⊣/⊢)                 ⍝ adjoining: last of ⍺, first of ⍵
               gap←∧/(⍺ adj ⍵)∊⍺⍺,'¯',⎕D       ⍝ gap required between words ⍺ ⍵
               ∊1 gap 1/⍺' '⍵                  ⍝ separated sections
           }                                   ⍝ :: expr ← expr ∇ expr
-     
+
           name←{(↓⌽↑⌽¨⍺),¨(⊂' ← '),¨⍵}⍣N      ⍝ with "name ← ..."
-     
+
           ↑(⊃¨⍵)name 0 xpr¨¯2↑¨⍵              ⍝ formatted definitions
       }
 
       externs←{                               ⍝ External names referenced by fn ⍵.
-     
+
           exts←{                              ⍝ external references
               1≠≡⍵:⍺ ∇ foldl ⍵,⊂,'⋄'          ⍝ inner fn: traverse
               X L P←⍺                         ⍝ Externals Locals Pending
@@ -682,7 +682,7 @@
               ~(⊃⍵)∊'⋄:':⍺                    ⍝ more in segment: continue
               (X∪P)L ⍬                        ⍝ end-of-segment: pending → external
           }                                   ⍝ :: [envt] ← [envt] ∇ func
-     
+
           nest←{                              ⍝ nested tokens for nested functions
               ⍺←+\1 ¯1 0[(,¨'{}')⍳⍵]          ⍝ {}-nesting depths
               outer←⊃,(⊃⌽)                    ⍝ outermost tokens
@@ -694,35 +694,35 @@
               cut←1++\lft∨rgt                 ⍝ chopping at inner {} sections
               ⊃,/(cut⊆⍺)∇¨sort cut⊆⍵          ⍝ diamond and guard segs
           }                                   ⍝ :: func ← ∇ [tokn]
-     
+
           sort←{                              ⍝ inner functions deferred until last
               ord←⍋⊃¨⍺                        ⍝ depth-of-segment order
               deps←(⊂ord)⌷⍺                   ⍝ depths
               segs←(⊂ord)⌷⍵                   ⍝ code segments
               deps ⍺⍺ segs                    ⍝ nesting per segment
           }                                   ⍝ :: func ← [[deps]] ∇ [[toks]]
-     
+
           clean←{                             ⍝ de-fluffing of tokens vectors
               join←{¯1↓⊃,/⍵,¨⊂⊂,'⋄'}          ⍝ diamonds for newlines
               rmcm←{('⍝'≠⊃¨⍵)/⍵}              ⍝ without comments
               rmps←~∘(,¨'()')                 ⍝ without parens: '(a b)←' → 'a b←'
               ''glue foldl rmps rmcm join ⍵   ⍝ clean token vector
           }                                   ⍝ :: [tokn] ← ∇ [[tokn]]
-     
+
           glue←{                              ⍝ gluing of compound name tokens a.b.c
               '.'≠⊃⊃⌽⍺:⍺,⊂⍵                   ⍝ not a '.' token: continue
               ~(⊃⍵)∊alph:⍺,⊂⍵                 ⍝ not a dotted name: continue
               (¯2↓⍺),⊂∊(¯2↑⍺),⍵               ⍝ dotted name: 'a.' 'b' → 'a.b'
           }                                   ⍝ :: [tokn] ← [tokn] ∇ tokn
-     
+
           foldl←{⊃⍺⍺⍨/(⌽⍵),⊂⍺}                ⍝ fold left
-     
+
           alph←{(0≤⎕NC⍪⍵)/⍵}⎕AV~'⍺⍵∇'         ⍝ start-of-name chars
-     
+
           envt←⍬ ⍬ ⍬                          ⍝ Externs Locals Pending
           ⍺←0 ⋄ toks←60⌶,¨,⊆⎕NR⍣(~⍺)⊢⍵,⍺↑'⋄'  ⍝ unofficial: tokens from nested rep'n of function
           ⊃envt exts foldl nest clean toks    ⍝ external names
-     
+
     ⍝ 0 externs :: [name] ← ∇ name      ⍝ names referenced by dfn ⍵
     ⍝ 1 externs :: [name] ← ∇ func      ⍝ names referenced by ⎕CR form ⍵
     ⍝      func := [tokn] | [func]      ⍝ function body: nested tokens vectors
@@ -796,7 +796,7 @@
       exprs,←⊂'0.0007125 0.000735 0.0007575 0.00078 0.0008025 0.000825 0.0008475 0.0008625'
       exprs,←⊂'0.0007125 0.0007125 0.000735 0.0007575 0.00078 0.0008025 0.000825 0.0008475 0.0008625'
       exprs,←⊂'0.0007125 0.0007125 0.0007125 0.000735 0.0007575 0.00078 0.0008025 0.000825 0.0008475 0.0008625'
-     
+
       Match←{⎕FR←⊃1287 645⌽⍨1289=⎕DR ⍺ ⋄ 0::0 ⋄ ⍺≡⍵}
       :For ⎕IO :In 0 1
           :For ⎕FR :In 645 1287
@@ -814,7 +814,7 @@
 
       repObj←{ ⍝ String representation of object V0.35
       ⍝ Optional left arg: parenthesise if needed to isolate expression in context
-     
+
           ⎕IO←1
 
           ⍺←0 ⍝ parenthesise if expression
@@ -838,28 +838,28 @@
               (rc ref)←2↑⍺
               or←scal∧1=≡R←⍵   ⍝ normally no funny objects like ⎕ORs
               or∨9=⎕NC'R':ref{~⍺:⎕SIGNAL⊂('EN' 11)('Message' 'Cannot represent refs') ⋄ ⍵}⍕⍵     ⍝ display refs as they are
-     
+
 ⍝ Reduce object to 1 item if all same elements
               mod←(0<rank)∧(n=0)∨(5×char)<n←×/s
               mod←mod∧as←char{0∊⍴⍵:1 ⋄ 11::0 ⋄ ⍵∧.≡1↑⍵}obj←,⍵ ⍝ as: all the same (Mantis 18499)
               obj←mod{16::⊂'[ref]' ⋄ 1(↑⍣⍺)⍵}obj  ⍝ take only 1st? (grab prototype if empty)
               shape←mod{⍵≡,1:',' ⋄ (⍺∨1<⍴⍵)/'⍴',⍨⍕⍵}s
               shape←shape,(encl←simple<as)⍴'⊂'
-     
-     
+
+
 ⍝ Reduce object to shortest viable prefix
               len←1⍳⍨(obj≡s⍴↑∘obj)¨⍳n
               len<≢obj:P⍣rc⊢(⍕s),'⍴',0 ref ∇ obj⍴⍨len~1
-     
+
 ⍝ Simple scalars and char vector≠⍴1 do not need parens
               parens←rc∧simple≤(0<⍴shape)∨(rank=1)∧num∨{80 82 160 320∊⍨⎕DR ⍵:∨/0 8 10 13 133∊⎕UCS ⍵ ⋄ 0}⍵
               (lp rp)←parens⍴¨'()'
               Paren←{>/'⎕' 'ADÁN'∊¨⍨2↑⍵:P ⍵ ⋄ ⍵} ⍝ Parenthesise complex expressions
               ~simple:rp,⍨lp,shape,encl{⍺⍲'('=1↑⍵:⍵ ⋄ 1↓¯1↓⍵}1↓⊃,/' ',¨Paren¨1 ref∘∇¨obj
-     
+
 ⍝ Simple objects (char should account for ⎕TC chars et al.)
               ⎕PP←34 ⍝ for numbers
-     
+
               cmpv←{⎕DCT←⎕CT←⎕IO←0                    ⍝ compress numeric vector
                   ⎕FR←645 1287[1289≠⎕DR ⍵]       ⍝ outer array may have been nested
                   ∨/e←(0∊s),⍬≡s←⍴v←⍵:⍕e/'⍬',1↑v  ⍝ empty or scalar
@@ -889,7 +889,7 @@
                   ⍵≡⍎fmt:ob,cb,⍨⍕⍵
                   ⎕SIGNAL⊂('EN' 16)('Message' 'Generated expression did not match argument')⍝ NONCE
               }
-     
+
               obj←shape,num ⍺{1↑⍺:cmpv ⍵ ⋄ ⎕ML←1 ⋄ ⎕IO←0 ⋄ QU←{Q,((1+t=Q)/t←⍵),Q←''''}
           ⍝ We have to assume not all characters are available. Those should be:
                   Always←⎕A,⎕D,'abcdefghijklmnopqrstuvwxyz_.,:;%!"/=\-+''#$£¢^¿¡(){}[]§@`∣¶&'
@@ -954,7 +954,7 @@
       ⎕ML←1 ⋄ E←'enclosed' ⍝ for ⊂
      ⍝ Character strings are transformed into a more suitable format
       :Select type←2⊃,mat←'whitespace' 'preserve'⎕XML⍣(0 2∊⍨10|⎕DR string)+string
-     
+
       :CaseList 'array'E
       ⍝ The array could be enclosed several times
           n←2+enc←+/∧\mat[;2]∊⊂E

--- a/StartupSession/Dyalog/Utils.apln
+++ b/StartupSession/Dyalog/Utils.apln
@@ -49,7 +49,7 @@
       r←⊢/∊'V'⎕VFI⊃⎕SRC ⎕THIS
     ∇
 
-    where←{⍵/⍳⍴⍵}        ⍝ Indices of 1's in ⎕IO 1
+    where←⍸
 
     ∇ r←{origin}Config param;os;ver;NamesValues;EnvVars;env;claValues;Names;cla;cfg;all;OnlySet;val;loc;Adjust;ErrIf;cmd;⎕USING;sk;hk;key;name
     ⍝ Values of configuration parameters (optionally with origin)


### PR DESCRIPTION
- **remove trailing spaces**
- **where: {⍵/⍳⍴⍵} -> ⍸**